### PR TITLE
Remove rake require

### DIFF
--- a/will_paginate-liquidized.gemspec
+++ b/will_paginate-liquidized.gemspec
@@ -3,7 +3,7 @@ Gem::Specification.new do |s|
   s.summary     = "will_paginate-liquidized"
   s.authors     = ["Jim Gilliam", "David Huie"]
   s.version     = "1"
-  s.files       = FileList["lib/**/*.rb"].to_a
+  s.files       = Dir["lib/**/*.rb"].to_a
   s.add_runtime_dependency "will_paginate"
   s.add_runtime_dependency "liquid"
 end

--- a/will_paginate-liquidized.gemspec
+++ b/will_paginate-liquidized.gemspec
@@ -1,5 +1,3 @@
-require 'rake'
-
 Gem::Specification.new do |s|
   s.name        = 'will_paginate-liquidized'
   s.summary     = "will_paginate-liquidized"


### PR DESCRIPTION
This worked in Ruby 1.9 but has since been removed.